### PR TITLE
Status line: richer session info + /clear bug fix

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -5,8 +5,11 @@
 
 input=$(cat)
 
-# One jq call, tab-separated; missing keys become "".
-IFS=$'\t' read -r cwd model ctx cost five five_reset seven seven_reset < <(
+# One jq call. Join with the ASCII Unit Separator (0x1F), NOT a tab: `read`
+# treats tab as IFS-whitespace and COLLAPSES an empty field (e.g. a null
+# rate-limit right after /clear), shifting every later value left by one. 0x1F
+# is non-whitespace, so empty fields are preserved and alignment holds.
+IFS=$'\037' read -r cwd model ctx cost five five_reset seven seven_reset added removed effort < <(
     printf '%s' "$input" | jq -r '
         [ .cwd,
           .model.display_name,
@@ -15,8 +18,11 @@ IFS=$'\t' read -r cwd model ctx cost five five_reset seven seven_reset < <(
           .rate_limits.five_hour.used_percentage,
           .rate_limits.five_hour.resets_at,
           .rate_limits.seven_day.used_percentage,
-          .rate_limits.seven_day.resets_at
-        ] | map(. // "") | @tsv'
+          .rate_limits.seven_day.resets_at,
+          .cost.total_lines_added,
+          .cost.total_lines_removed,
+          .effort.level
+        ] | map(. // "" | tostring) | join("")'
 )
 [ -z "$cwd" ] && cwd=$(pwd)
 dir_name=$(basename "$cwd")
@@ -24,24 +30,31 @@ dir_name=$(basename "$cwd")
 # ANSI colors (appear dimmed in Claude's status bar)
 txtcyn="\e[36m"
 txtred="\e[31m"
+txtylw="\e[33m"
 txtrst="\e[0m"
 
-# Git branch and dirty status
+# Git branch, dirty flag, and ahead/behind the upstream (↑ unpushed, ↓ unpulled)
 git_branch=""
 git_dirty=""
+git_ab=""
 if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
     branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null \
              || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
     [ -n "$branch" ] && git_branch="$branch "
     [ -n "$(git -C "$cwd" status --porcelain 2>/dev/null)" ] && git_dirty="*"
+    if ab=$(git -C "$cwd" rev-list --left-right --count '@{u}...HEAD' 2>/dev/null); then
+        read -r behind ahead <<< "$ab"
+        [ "${ahead:-0}" -gt 0 ] && git_ab="${git_ab}↑${ahead}"
+        [ "${behind:-0}" -gt 0 ] && git_ab="${git_ab}↓${behind}"
+    fi
 fi
 
-printf "%s@%s %s %b%s%b%s%b" \
-    "$(whoami)" \
-    "$(hostname -s)" \
+# dir + git only (dropped user@host — constant on a personal machine)
+printf "%s %b%s%b%s%b%s%b" \
     "$dir_name" \
     "$txtcyn" "$git_branch" \
     "$txtred" "$git_dirty" \
+    "$txtylw" "$git_ab" \
     "$txtrst"
 
 # --- Primary agent: model · context% · cost · plan usage ---
@@ -55,9 +68,9 @@ pctcol() {  # $1 = integer percent -> emit the severity color
     elif [ "$1" -ge 65 ]; then printf '%s' "$c_md"
     else printf '%s' "$c_lo"; fi
 }
-# Session-scoped trio: model · context% · cost
+# Session-scoped group: model · context% · cost · lines · effort
 sess=""
-[ -n "$model" ] && sess="$model"
+[ -n "$model" ] && sess="${model%% (*}"   # strip "(1M context)" suffix
 if [ -n "$ctx" ]; then
     ctx_i=$(printf '%.0f' "$ctx" 2>/dev/null)
     [ -n "$ctx_i" ] && sess="${sess:+$sess }$(pctcol "$ctx_i")${ctx_i}%${c_rst}"
@@ -66,6 +79,12 @@ if [ -n "$cost" ]; then
     cost_f=$(printf '$%.2f' "$cost" 2>/dev/null)
     [ -n "$cost_f" ] && sess="${sess:+$sess }${cost_f}"
 fi
+# Session code churn: +added/-removed (green/red), only when non-zero
+if { [ "${added:-0}" -gt 0 ] || [ "${removed:-0}" -gt 0 ]; } 2>/dev/null; then
+    sess="${sess:+$sess }${c_lo}+${added:-0}${c_rst}/${c_hi}-${removed:-0}${c_rst}"
+fi
+# Reasoning effort level (e.g. high / xhigh)
+[ -n "$effort" ] && sess="${sess:+$sess }${c_dim}⚡${effort}${c_rst}"
 # Bracket the session trio (dim brackets) to set it apart from the
 # account-scoped plan usage, which stays OUTSIDE the brackets.
 seg=""


### PR DESCRIPTION
## What

- **Bug fix (the important one):** after \`/clear\`, \`rate_limits\` is momentarily absent, so the tab-separated \`read\` collapsed the empty field and shifted every later value — reset timestamps rendered as \`1785108600%\`. Fields are now read as a **0x1F-separated array**, so empty fields are preserved and the line degrades cleanly.
- **Added:** git ahead/behind vs upstream (\`↑\` unpushed / \`↓\` unpulled), session code churn (\`+133/-13\`), and reasoning effort level (\`⚡high\`).
- **Trimmed:** \`user@host\` and the \`(1M context)\` model suffix to keep it short.

## Tested

Normal render, \`/clear\` case (rate_limits absent → graceful degradation), and the ahead/behind path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)