### PR TITLE
docs: drop stale 'Not yet managed' README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,3 @@ cd ~/src/dots && git pull                                 # update
   **fail-closed** (no global name/email — set per-repo), so nothing identifying
   is here. Machine/work-specific overrides go in `~/.gitconfig.local` (included
   at the end, not committed).
-
-## Not yet managed
-
-- **`.gitconfig.personal`** — orphan (holds a bare email, nothing includes it).
-  Contradicts the fail-closed model; decide whether to delete it or repurpose.


### PR DESCRIPTION
The `.gitconfig.personal` orphan that section described was deleted in `03487b90`, and `.bashrc` / `.vimrc` / `.gitconfig` / `.claude` are all managed now — so the "Not yet managed" section is stale and removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)