### PR TITLE
docs: document the shared-plus-local pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,44 @@ cd ~/src/dots && git pull                                 # update
 - Any existing real file is backed up to `~/.dotfiles-backup/<timestamp>/`
   before being replaced with a symlink. Re-running is safe and idempotent.
 
+## Shared + local split
+
+This repo holds only the **general** config — the parts that are safe to commit
+to a public repo and identical on every machine. Anything machine-specific,
+work-specific, or secret stays in an untracked `*.local` companion in `$HOME`
+that the shared file pulls in at the end. The repo never sees it.
+
+Each shared file loads its local companion through that tool's own include
+mechanism:
+
+| Shared file (tracked)   | Local companion (untracked) | How it's loaded                        |
+|-------------------------|-----------------------------|----------------------------------------|
+| `.bashrc`               | `~/.bashrc.local`           | `[ -f ~/.bashrc.local ] && . ~/.bashrc.local` |
+| `.claude/CLAUDE.md`     | `~/.claude/CLAUDE.local.md` | `@~/.claude/CLAUDE.local.md` import     |
+| `.gitconfig`            | `~/.gitconfig.local`        | `[include] path = ~/.gitconfig.local`   |
+
+The local files are created by hand per machine — `install.sh` neither creates
+nor links them, and the shared files tolerate their absence (a missing
+companion is simply skipped). What belongs in them:
+
+- **Secrets and secret loaders** — API tokens, anything read from 1Password or a
+  credential store.
+- **Work-specific config** — internal tooling, employer paths, VPN/SSO helpers.
+- **Machine-specific paths** — app locations that differ between laptops.
+
+Nothing identifying or sensitive lives in the tracked files. Git identity is
+**fail-closed**: `.gitconfig` sets no global name/email (`useConfigOnly = true`),
+so every repo requires an explicit per-repo `user.email` — a wrong-identity
+commit fails rather than silently using the wrong address.
+
 ## What's managed
 
-- **`.claude/`** — Claude Code config: `CLAUDE.md`, routing-fleet agents, and
-  the status-line scripts. Machine-local Claude files (`settings.json`,
-  `CLAUDE.local.md`, `metrics/`) are intentionally **not** tracked, so work and
-  home machines don't interfere. Env-specific instructions go in
-  `~/.claude/CLAUDE.local.md` (imported by the shared `CLAUDE.md`).
-- **`.bashrc`** — the general part. Machine/work-specific bits (paths, work
-  1Password/AWS, etc.) live in `~/.bashrc.local`, which the shared `.bashrc`
-  sources at the end and which is **never committed**. Same shared-plus-local
-  pattern as `CLAUDE.md` + `CLAUDE.local.md`.
+- **`.bashrc`** — general shell config: aliases, prompt, and helper functions.
+- **`.claude/`** — Claude Code config: `CLAUDE.md`, routing-fleet agents, and the
+  status-line scripts. Machine-local Claude files (`settings.json`, `metrics/`)
+  are intentionally not tracked so work and home machines don't interfere.
 - **`.vimrc`** — general vim config.
-- **`.gitconfig`** — general git config + signing settings. Identity is
-  **fail-closed** (no global name/email — set per-repo), so nothing identifying
-  is here. Machine/work-specific overrides go in `~/.gitconfig.local` (included
-  at the end, not committed).
+- **`.gitconfig`** — general git config + SSH commit signing.
+
+See [Shared + local split](#shared--local-split) for where the machine-specific
+half of `.bashrc`, `CLAUDE.md`, and `.gitconfig` lives.


### PR DESCRIPTION
Pulls the per-file repetition into one section: a table mapping each shared file to its untracked `*.local` companion and load mechanism, what belongs local (secrets, work config, machine paths), and the fail-closed git identity rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)