### PR TITLE
feat(git): live-model co-author trailer + prepare-commit-msg hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -95,6 +95,13 @@ Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `build
 - **Blank line, then a body.** The body explains both **what** the change does and **why** it was needed. "How" is the diff — skip it.
 - Wrap body lines at 72 characters.
 - Trivial commits (formatting, rename, dep bump) can be a one-liner with no body.
+- **Co-author trailer names the live model.** When appending
+  `Co-Authored-By: Claude … <noreply@anthropic.com>`, use the display name of
+  the model actually running the session (e.g. `Claude Opus 4.8`), never a name
+  carried over from base instructions. If unsure of the exact display name,
+  derive it from the most recent `"model"` id in the session transcript. A
+  `prepare-commit-msg` hook (see the dots repo) normalizes this deterministically
+  as a backstop, but get it right in the message you write.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ commit fails rather than silently using the wrong address.
   are intentionally not tracked so work and home machines don't interfere.
 - **`.vimrc`** — general vim config.
 - **`.gitconfig`** — general git config + SSH commit signing.
+- **`git-hooks/`** — git hooks deployed by `install.sh` (not `$HOME` symlinks):
+  each is linked into `~/.git_templates/hooks/` so new clones inherit it, and
+  into this repo's own `.git/hooks/`. `prepare-commit-msg` keeps the Claude
+  `Co-Authored-By` trailer naming the model actually running, resolved from the
+  Claude Code session transcript. `install.sh` never sets `core.hooksPath`
+  globally, so other repos' own hooks are untouched; existing repos pick the
+  hook up by re-running `git init` (re-applies the template).
 
 See [Shared + local split](#shared--local-split) for where the machine-specific
 half of `.bashrc`, `CLAUDE.md`, and `.gitconfig` lives.

--- a/git-hooks/prepare-commit-msg
+++ b/git-hooks/prepare-commit-msg
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# prepare-commit-msg — keep the Claude Co-Authored-By trailer honest.
+#
+# When a commit message carries a "Co-Authored-By: Claude ..." line (i.e. a
+# Claude-made commit), rewrite it to name the model actually running the
+# session, resolved from the Claude Code session transcript. This corrects the
+# hardcoded model name Claude emits from its base instructions, which goes
+# stale whenever a session runs a different model.
+#
+# Safe by construction:
+#   - acts ONLY when a "Co-Authored-By: Claude" line is already present
+#   - human co-author lines are never touched
+#   - fail-open: any uncertainty (no session, no transcript, unknown model id)
+#     leaves the message exactly as-is and never blocks the commit
+set -u
+
+msg_file="${1:-}"
+[ -n "$msg_file" ] && [ -f "$msg_file" ] || exit 0
+
+# Nothing to do unless a Claude co-author line exists.
+grep -qiE '^Co-Authored-By: Claude' "$msg_file" || exit 0
+
+# Need the Claude Code session to know which model is running.
+sid="${CLAUDE_CODE_SESSION_ID:-}"
+[ -n "$sid" ] || exit 0
+
+# Most recent model id recorded in this session's transcript.
+transcript="$(find "$HOME/.claude/projects" -maxdepth 3 -type f -name "${sid}.jsonl" 2>/dev/null | head -1)"
+[ -n "$transcript" ] && [ -f "$transcript" ] || exit 0
+model_id="$(grep -oE '"model":"[^"]*"' "$transcript" 2>/dev/null | tail -1 | sed -E 's/.*"model":"([^"]*)".*/\1/')"
+[ -n "$model_id" ] || exit 0
+case "$model_id" in claude-*) ;; *) exit 0 ;; esac
+
+# claude-opus-4-8 -> "Claude Opus 4.8"  |  claude-fable-5 -> "Claude Fable 5"
+x="${model_id%%[*}"                              # strip alias suffix e.g. [1m]
+x="${x#claude-}"
+x="$(printf '%s' "$x" | sed -E 's/-[0-9]{8}$//')" # strip trailing release date
+fam="${x%%-*}"
+ver="${x#*-}"; [ "$ver" = "$x" ] && ver=""
+fam="$(tr '[:lower:]' '[:upper:]' <<<"${fam:0:1}")${fam:1}"
+ver="${ver//-/.}"
+if [ -n "$ver" ]; then display="Claude $fam $ver"; else display="Claude $fam"; fi
+
+# Rewrite only Claude co-author lines; leave everything else intact.
+tmp="$(mktemp)" || exit 0
+if sed -E "s|^Co-Authored-By: Claude.*|Co-Authored-By: ${display} <noreply@anthropic.com>|" "$msg_file" >"$tmp" 2>/dev/null; then
+  cat "$tmp" >"$msg_file"
+fi
+rm -f "$tmp"
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -60,12 +60,59 @@ link_one() {
   fi
 }
 
+# Git hooks to deploy. Unlike dotfiles these are not $HOME symlinks: each is
+# symlinked into the git template dir (so new clones/inits inherit it) and into
+# this repo's own .git/hooks (so dots itself is covered now). We deliberately do
+# NOT set core.hooksPath globally — that would silently disable every other
+# repo's own hooks.
+GIT_TEMPLATE_HOOKS="$HOME/.git_templates/hooks"
+HOOKS=(
+  prepare-commit-msg
+)
+
+link_hook() {
+  local name="$1"
+  local src="$DOTS/git-hooks/$name"
+  if [ ! -e "$src" ]; then
+    echo "  MISSING-IN-REPO  git-hooks/$name"
+    return
+  fi
+  [ "$DRY" = 0 ] && chmod +x "$src"
+  local dst
+  for dst in "$GIT_TEMPLATE_HOOKS/$name" "$DOTS/.git/hooks/$name"; do
+    if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
+      echo "  ok               hook $dst"
+      continue
+    fi
+    if [ -e "$dst" ] || [ -L "$dst" ]; then
+      echo "  BACKUP+LINK      hook $dst  (existing -> ~/.dotfiles-backup/)"
+      if [ "$DRY" = 0 ]; then
+        mkdir -p "$BACKUP/hooks"
+        mv "$dst" "$BACKUP/hooks/$(basename "$dst").$(basename "$(dirname "$(dirname "$dst")")")"
+      fi
+    else
+      echo "  LINK             hook $dst"
+    fi
+    if [ "$DRY" = 0 ]; then
+      mkdir -p "$(dirname "$dst")"
+      ln -s "$src" "$dst"
+    fi
+  done
+}
+
 echo "dots at: $DOTS"
 [ "$DRY" = 1 ] && echo "(dry-run — nothing will change)"
 for rel in "${MANIFEST[@]}"; do
   link_one "$rel"
 done
+for hook in "${HOOKS[@]}"; do
+  link_hook "$hook"
+done
 if [ "$DRY" = 0 ] && [ -d "$BACKUP" ]; then
   echo "replaced files backed up to: $BACKUP"
 fi
 echo "done."
+echo
+echo "note: existing repos cloned before this hook won't have it — re-run"
+echo "      'git init' inside them to re-apply the template, or symlink"
+echo "      $DOTS/git-hooks/prepare-commit-msg into <repo>/.git/hooks/."


### PR DESCRIPTION
The `Co-Authored-By` line Claude emits is hardcoded in its base instructions and names one model, so it goes stale whenever a session runs a different model.

- **prepare-commit-msg hook** rewrites any `Co-Authored-By: Claude …` line to the model actually running, resolved from the Claude Code session transcript. Fail-open (no session / no transcript / unknown model / human co-author → left untouched, never blocks a commit); model→name mapping is algorithmic so it won't itself go stale.
- **CLAUDE.md rule** to name the live model at write time.
- **install.sh** deploys the hook via the git template dir + this repo; deliberately does not set `core.hooksPath` globally, so other repos' hooks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)