### PR TITLE
docs(claude): add conventions for claims, comments and refs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,6 +80,22 @@ Two exceptions:
   The test is whether a reader would treat the number as *why this code looks
   like this* (keep) or as *what the system currently does* (drop).
 
+## Cross-context references
+
+A reference that resolves correctly where you wrote it can silently resolve to something
+else where it is read. Two cases that bite:
+
+**Bare `#N` is repo-local.** In a GitHub PR body, issue, or comment, `#602` means issue or
+PR 602 *in the current repo*. Pointing at another repo needs `owner/repo#602` or a full
+URL. Get this wrong and it doesn't error — it links to an unrelated item that usually
+exists, which is worse than a broken link.
+
+**Relative links don't resolve in PR and issue bodies.** `./README.md` or `../docs/x.md`
+work in a rendered repo file but break in a PR description, an issue, or a PR template.
+Use full `https://github.com/owner/repo/...` URLs in those.
+
+When unsure, use the full URL. It is never wrong, only longer.
+
 ## Output formatting
 
 When using abbreviations in output (e.g., TSS, RPE, RUM, APM, MoM, WoW),

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,55 @@ not as personal fault or hard-won experience. First-person action ("I'll fix
 it", "I changed X") is fine; it's the personified blame/feeling/experience
 framing to drop.
 
+## Code comments and committed docs
+
+Never put point-in-time measurements in code comments, config comments, or
+committed docs. They rot within weeks and then actively mislead, because nothing
+re-verifies them when the underlying system changes. This covers observed values
+and counts ("~413 hosts carry no cluster tag", "peak was 5.51%", "1 of ~4750
+groups exceeded this"), current-state claims ("there are 12 clusters", "this
+runs on 3 replicas"), and bare dates or "as of" qualifiers.
+
+Comment the **durable reason** instead — the invariant, the mechanism, or the
+constraint that will still hold after the numbers move:
+
+```hcl
+# BAD  — rots as soon as the fleet changes
+# Grouped by host, not kube_cluster_name -- ~413 non-EKS hosts carry no cluster tag.
+
+# GOOD — states why, and stays true
+# Grouped by host, not kube_cluster_name: much of the non-EKS fleet carries no
+# cluster tag, and a missing tag is not filterable, so those hosts would
+# silently collapse into a single group.
+```
+
+For a tuned threshold, say what it is set relative to and how to re-derive it —
+not the reading it came from.
+
+The measurements themselves are still worth recording; put them where they are
+inherently timestamped and never mistaken for current truth: the commit message,
+the PR description, or a linked ticket. Prefer making a value queryable or
+asserted in a test over describing it in prose.
+
+Two exceptions:
+
+- A comment describing the state of a *pinned, versioned* dependency is fine,
+  since it changes only when the pin does.
+- A measurement that gives a design decision its meaning is worth keeping
+  inline — a benchmark beside an optimization, a baseline that explains what
+  "fast" or "too big" meant when the threshold was chosen. Without it the
+  decision becomes unreadable and the next person cannot tell whether it still
+  holds. Frame it explicitly as a historical datum rather than current state,
+  and anchor it to something concrete so nobody mistakes it for a live value:
+
+  ```python
+  # 40ms -> 3ms on the 10k-row fixture (M2, Python 3.12) when this replaced the
+  # naive nested loop. Re-measure before assuming it still matters.
+  ```
+
+  The test is whether a reader would treat the number as *why this code looks
+  like this* (keep) or as *what the system currently does* (drop).
+
 ## Output formatting
 
 When using abbreviations in output (e.g., TSS, RPE, RUM, APM, MoM, WoW),

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,6 +23,32 @@ it — especially before putting it in a shared/public artifact. When something
 genuinely cannot be proven, label it explicitly as an inference and state what
 would confirm it.
 
+**Don't overstate — verify.** Every link in a causal or attributive claim needs
+its own measurement. A chain where some links are measured and others assumed
+must have the assumed links labelled explicitly, or not be presented at all.
+Before asserting, ask: "which specific query proves *this* link?" If none does,
+run it or label it. Recurring failure modes to check for:
+
+- **Unvalidated proxy metrics.** Read the source before trusting any metric or
+  log line as a stand-in for a business event. A counter assumed to be driven by
+  user activity may be driven by a cron sweeper.
+- **Attribution by the wrong measure.** Share-of-time is not share-of-volume. If
+  one actor's units of work are slower, it dominates time while being a minority
+  of volume. State which was measured.
+- **Scope drift between measurements.** Measuring A system-wide and B for one
+  component, then stating the conclusion as though both had the same scope.
+- **Relocation vs. increase.** Before calling something a surge, check whether
+  the work merely moved — same volume, new location, different performance.
+- **Loaded vocabulary.** Words like "regression", "leak", "spike" assert a
+  mechanism. Use them only once that mechanism is established; otherwise state
+  what was measured ("duration rose while request volume did not").
+- **Rejecting a hypothesis on adjacent evidence.** Dismissing a deploy because
+  the running version is old, without checking what the *previous* version was,
+  rejects a different claim than the one under test.
+
+Prefer a labelled open question over a smooth narrative. A confident wrong
+conclusion sends people down a false path and costs more than "not established".
+
 Don't use self-personifying blame, ownership, or experiential phrasing such as
 "that's on me", "my mistake", "my bad", "I've been burned", or "lesson learned"
 — you are computer code, not a person, and have no feelings or lived experience
@@ -30,6 +56,13 @@ to draw on. Describe errors and risks factually: state what was wrong and why,
 not as personal fault or hard-won experience. First-person action ("I'll fix
 it", "I changed X") is fine; it's the personified blame/feeling/experience
 framing to drop.
+
+Don't narrate your own reasoning history. Cut openers like "worth being blunt
+about X, because I undersold it", "let me be precise about what survived", "I've
+moved position twice", and running tallies of where you were previously wrong.
+When a correction changes what I would do, state it in one plain sentence and
+move on; when it changes nothing, make it silently. This is separate from the
+substantive caveats and labelled inferences above — keep those.
 
 ## Code comments and committed docs
 


### PR DESCRIPTION
- Ban point-in-time measurements in code comments, config comments and committed docs; comment the durable reason instead
  - Two narrow exceptions kept: a comment describing a pinned, versioned dependency, and a benchmark that gives a design decision its meaning
- Warn that a bare `#N` reference resolves repo-locally in a PR or issue body, and that relative links do not resolve there at all
- Require each link in a causal or attributive claim to carry its own measurement, naming the recurring failure modes
- Ban narrating reasoning history, while keeping the substantive caveats and labelled inferences
